### PR TITLE
[#2] 매장 배달 상태 조회(SSE) 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/src/main/generated/
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,17 @@ dependencies {
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
-    // Postgresql
-    implementation("org.postgresql:postgresql:42.7.5")
-
     // Jpa
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.4.4")
 
+    // Postgresql
+    runtimeOnly("org.postgresql:postgresql:42.7.5")
+
     // H2
     runtimeOnly("com.h2database:h2:2.3.232")
+
+    // Redis
+    implementation("org.redisson:redisson-spring-boot-starter:3.45.1")
 
     // Kafka
     implementation("org.springframework.kafka:spring-kafka:3.3.4")

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     // H2
     runtimeOnly("com.h2database:h2:2.3.232")
 
+    // Kafka
+    implementation("org.springframework.kafka:spring-kafka:3.3.4")
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/baedal/delivery/adapter/in/event/DeliveryEventHandler.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/event/DeliveryEventHandler.java
@@ -1,9 +1,11 @@
 package com.baedal.delivery.adapter.in.event;
 
+import com.baedal.delivery.adapter.in.event.mapper.DeliveryEventMapper;
 import com.baedal.delivery.application.event.DeliveryCreatedEvent;
 import com.baedal.delivery.application.event.DeliveryStatusUpdatedEvent;
 import com.baedal.delivery.application.port.out.DeliveryCachePort;
 import com.baedal.delivery.application.port.out.DeliveryMessagePublisherPort;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -17,15 +19,19 @@ public class DeliveryEventHandler {
 
   private final DeliveryMessagePublisherPort messagePublisher;
 
+  private final DeliveryEventMapper mapper;
+
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handle(DeliveryStatusUpdatedEvent event) {
     cachePort.saveStatus(event.getDeliveryId(), event.getStoreId(), event.getStatus());
-    messagePublisher.deliveryStatusUpdate(event.getStoreId(), event.getStatus());
+    UpdateDeliveryStatus model = mapper.toDomain(event.getDeliveryId(), event.getStatus());
+    messagePublisher.deliveryStatusUpdate(event.getStoreId(), model);
   }
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handle(DeliveryCreatedEvent event) {
     cachePort.saveStatus(event.getDeliveryId(), event.getStoreId(), event.getStatus());
-    messagePublisher.deliveryStatusUpdate(event.getStoreId(), event.getStatus());
+    UpdateDeliveryStatus model = mapper.toDomain(event.getDeliveryId(), event.getStatus());
+    messagePublisher.deliveryStatusUpdate(event.getStoreId(), model);
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/in/event/DeliveryEventHandler.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/event/DeliveryEventHandler.java
@@ -1,0 +1,26 @@
+package com.baedal.delivery.adapter.in.event;
+
+import com.baedal.delivery.application.event.DeliveryCreatedEvent;
+import com.baedal.delivery.application.event.DeliveryStatusUpdatedEvent;
+import com.baedal.delivery.application.port.out.DeliveryCachePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryEventHandler {
+
+  private final DeliveryCachePort cachePort;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(DeliveryStatusUpdatedEvent event) {
+    cachePort.saveStatus(event.getDeliveryId(), event.getStoreId(), event.getStatus());
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(DeliveryCreatedEvent event) {
+    cachePort.saveStatus(event.getDeliveryId(), event.getStoreId(), event.getStatus());
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/event/DeliveryEventHandler.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/event/DeliveryEventHandler.java
@@ -3,6 +3,7 @@ package com.baedal.delivery.adapter.in.event;
 import com.baedal.delivery.application.event.DeliveryCreatedEvent;
 import com.baedal.delivery.application.event.DeliveryStatusUpdatedEvent;
 import com.baedal.delivery.application.port.out.DeliveryCachePort;
+import com.baedal.delivery.application.port.out.DeliveryMessagePublisherPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -14,13 +15,17 @@ public class DeliveryEventHandler {
 
   private final DeliveryCachePort cachePort;
 
+  private final DeliveryMessagePublisherPort messagePublisher;
+
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handle(DeliveryStatusUpdatedEvent event) {
     cachePort.saveStatus(event.getDeliveryId(), event.getStoreId(), event.getStatus());
+    messagePublisher.deliveryStatusUpdate(event.getStoreId(), event.getStatus());
   }
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handle(DeliveryCreatedEvent event) {
     cachePort.saveStatus(event.getDeliveryId(), event.getStoreId(), event.getStatus());
+    messagePublisher.deliveryStatusUpdate(event.getStoreId(), event.getStatus());
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/in/event/mapper/DeliveryEventMapper.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/event/mapper/DeliveryEventMapper.java
@@ -1,0 +1,11 @@
+package com.baedal.delivery.adapter.in.event.mapper;
+
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DeliveryEventMapper {
+
+  UpdateDeliveryStatus toDomain(Long deliveryId, DeliveryStatus status);
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/message/event/DeliveryCreateEvent.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/event/DeliveryCreateEvent.java
@@ -1,0 +1,15 @@
+package com.baedal.delivery.adapter.in.message.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliveryCreateEvent {
+
+  private Long orderId;
+
+  private Long storeId;
+
+  private Long customerId;
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/message/listener/DeliveryListener.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/listener/DeliveryListener.java
@@ -1,0 +1,27 @@
+package com.baedal.delivery.adapter.in.message.listener;
+
+import com.baedal.delivery.adapter.in.message.mapper.DeliveryListenerMapper;
+import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
+import com.baedal.delivery.application.port.in.DeliveryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryListener {
+
+  private final DeliveryListenerMapper deliveryMapper;
+  private final DeliveryUseCase deliveryUseCase;
+
+  @KafkaListener(topics = "delivery.updateDeliveryStatus", groupId = "updateDelivery")
+  public void updateDeliveryStatus(ConsumerRecord<String, String> record) {
+    String deliveryId = record.key();
+    String status = record.value();
+    UpdateDeliveryStatusCommand.Request command = deliveryMapper.updateDeliveryStatus(
+        deliveryId, status
+    );
+    deliveryUseCase.updateDeliveryStatus(command);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/message/listener/DeliveryListener.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/listener/DeliveryListener.java
@@ -1,8 +1,10 @@
 package com.baedal.delivery.adapter.in.message.listener;
 
+import com.baedal.delivery.adapter.in.message.event.DeliveryCreateEvent;
 import com.baedal.delivery.adapter.in.message.mapper.DeliveryListenerMapper;
 import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
 import com.baedal.delivery.application.port.in.DeliveryUseCase;
+import com.baedal.delivery.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class DeliveryListener {
 
   private final DeliveryListenerMapper deliveryMapper;
+
   private final DeliveryUseCase deliveryUseCase;
 
   @KafkaListener(topics = "delivery.updateDeliveryStatus", groupId = "updateDelivery")
@@ -23,5 +26,17 @@ public class DeliveryListener {
         deliveryId, status
     );
     deliveryUseCase.updateDeliveryStatus(command);
+  }
+
+  @KafkaListener(topics = "delivery.create", groupId = "createDelivery")
+  public void createDelivery(ConsumerRecord<String, String> record) {
+    String key = record.key();
+    DeliveryCreateEvent event = ObjectMapperUtil.jsonToDto(
+        record.value(), DeliveryCreateEvent.class);
+    deliveryUseCase.createDelivery(
+        event.getStoreId(),
+        event.getOrderId(),
+        event.getCustomerId()
+    );
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/in/message/listener/DeliveryStatusListener.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/listener/DeliveryStatusListener.java
@@ -1,0 +1,29 @@
+package com.baedal.delivery.adapter.in.message.listener;
+
+import com.baedal.delivery.application.service.DeliveryStatusPushService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryStatusListener implements MessageListener {
+
+  private final DeliveryStatusPushService service;
+
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    String channel = new String(message.getChannel());
+    String payload = new String(message.getBody());
+
+    Long storeId = extractStoreIdFromChannel(channel);
+    service.pushDeliveryStatus(storeId, payload);
+  }
+
+  private Long extractStoreIdFromChannel(String channel) {
+    // delivery:update:%d
+    String[] parts = channel.split(":");
+    return Long.parseLong(parts[2]);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/message/listener/RedisSubscriber.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/listener/RedisSubscriber.java
@@ -3,6 +3,7 @@ package com.baedal.delivery.adapter.in.message.listener;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Component;
@@ -17,10 +18,14 @@ public class RedisSubscriber {
 
   private final Map<Long, ChannelTopic> subscribedTopics = new ConcurrentHashMap<>();
 
+  @Value("${redis.channel-format.delivery-update}")
+  private String channelFormat;
+
   public synchronized void subscribe(Long storeId) {
     if (!subscribedTopics.containsKey(storeId)) {
       // TODO: key 값에 따른 Subscriber 클래스 분리 예정
-      ChannelTopic topic = new ChannelTopic("delivery:update:" + storeId);
+      String channelName = String.format(channelFormat, storeId);
+      ChannelTopic topic = new ChannelTopic(channelName);
       listenerContainer.addMessageListener(listener, topic);
       subscribedTopics.put(storeId, topic);
     }

--- a/src/main/java/com/baedal/delivery/adapter/in/message/listener/RedisSubscriber.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/listener/RedisSubscriber.java
@@ -1,0 +1,35 @@
+package com.baedal.delivery.adapter.in.message.listener;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber {
+
+  private final RedisMessageListenerContainer listenerContainer;
+
+  private final DeliveryStatusListener listener;
+
+  private final Map<Long, ChannelTopic> subscribedTopics = new ConcurrentHashMap<>();
+
+  public synchronized void subscribe(Long storeId) {
+    if (!subscribedTopics.containsKey(storeId)) {
+      // TODO: key 값에 따른 Subscriber 클래스 분리 예정
+      ChannelTopic topic = new ChannelTopic("delivery:update:" + storeId);
+      listenerContainer.addMessageListener(listener, topic);
+      subscribedTopics.put(storeId, topic);
+    }
+  }
+
+  public synchronized void unsubscribe(Long storeId) {
+    ChannelTopic topic = subscribedTopics.remove(storeId);
+    if (topic != null) {
+      listenerContainer.removeMessageListener(listener, topic);
+    }
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/message/mapper/DeliveryListenerMapper.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/mapper/DeliveryListenerMapper.java
@@ -1,0 +1,10 @@
+package com.baedal.delivery.adapter.in.message.mapper;
+
+import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DeliveryListenerMapper {
+
+  UpdateDeliveryStatusCommand.Request updateDeliveryStatus(String deliveryId, String status);
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/message/subscription/DeliveryStatusSubscriptionAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/message/subscription/DeliveryStatusSubscriptionAdapter.java
@@ -1,5 +1,7 @@
-package com.baedal.delivery.adapter.in.message.listener;
+package com.baedal.delivery.adapter.in.message.subscription;
 
+import com.baedal.delivery.adapter.in.message.listener.DeliveryStatusListener;
+import com.baedal.delivery.application.port.out.DeliveryStatusSubscriptionPort;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RedisSubscriber {
+public class DeliveryStatusSubscriptionAdapter implements DeliveryStatusSubscriptionPort {
 
   private final RedisMessageListenerContainer listenerContainer;
 
@@ -23,7 +25,6 @@ public class RedisSubscriber {
 
   public synchronized void subscribe(Long storeId) {
     if (!subscribedTopics.containsKey(storeId)) {
-      // TODO: key 값에 따른 Subscriber 클래스 분리 예정
       String channelName = String.format(channelFormat, storeId);
       ChannelTopic topic = new ChannelTopic(channelName);
       listenerContainer.addMessageListener(listener, topic);

--- a/src/main/java/com/baedal/delivery/adapter/in/web/controller/DeliveryController.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/web/controller/DeliveryController.java
@@ -1,6 +1,6 @@
 package com.baedal.delivery.adapter.in.web.controller;
 
-import com.baedal.delivery.adapter.in.web.manager.SseEmitterManager;
+import com.baedal.delivery.adapter.out.web.manager.StoreSseEmitterManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,12 +13,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/delivery")
 public class DeliveryController {
 
-  private final SseEmitterManager sseEmitterManager;
+  private final StoreSseEmitterManager storeSseEmitterManager;
 
   @GetMapping("/v0/{storeId}/stream")
   public SseEmitter getDeliveryStream(@PathVariable Long storeId) {
     SseEmitter emitter = new SseEmitter(); // Timeout milliseconds
-    sseEmitterManager.addEmitter(storeId, emitter);
+    storeSseEmitterManager.addEmitter(storeId, emitter);
     return emitter;
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/in/web/controller/DeliveryController.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/web/controller/DeliveryController.java
@@ -1,6 +1,10 @@
 package com.baedal.delivery.adapter.in.web.controller;
 
 import com.baedal.delivery.adapter.out.web.manager.StoreSseEmitterManager;
+import com.baedal.delivery.application.service.DeliveryService;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import com.baedal.delivery.util.ObjectMapperUtil;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,10 +19,21 @@ public class DeliveryController {
 
   private final StoreSseEmitterManager storeSseEmitterManager;
 
+  private final DeliveryService service;
+
   @GetMapping("/v0/{storeId}/stream")
   public SseEmitter getDeliveryStream(@PathVariable Long storeId) {
-    SseEmitter emitter = new SseEmitter(); // Timeout milliseconds
+    SseEmitter emitter = new SseEmitter(); // FIXME: Timeout milliseconds
     storeSseEmitterManager.addEmitter(storeId, emitter);
     return emitter;
   }
+
+  @GetMapping("/v0/{storeId}/notify-ready")
+  public void clientReady(@PathVariable Long storeId) {
+    List<UpdateDeliveryStatus> statuses = service.getStoresDeliveryStatus(storeId);
+    for (UpdateDeliveryStatus status : statuses) {
+      storeSseEmitterManager.sendToClients(storeId, ObjectMapperUtil.toJson(status));
+    }
+  }
+
 }

--- a/src/main/java/com/baedal/delivery/adapter/in/web/controller/DeliveryController.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/web/controller/DeliveryController.java
@@ -1,0 +1,24 @@
+package com.baedal.delivery.adapter.in.web.controller;
+
+import com.baedal.delivery.adapter.in.web.manager.SseEmitterManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/delivery")
+public class DeliveryController {
+
+  private final SseEmitterManager sseEmitterManager;
+
+  @GetMapping("/v0/{storeId}/stream")
+  public SseEmitter getDeliveryStream(@PathVariable Long storeId) {
+    SseEmitter emitter = new SseEmitter(); // Timeout milliseconds
+    sseEmitterManager.addEmitter(storeId, emitter);
+    return emitter;
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/in/web/manager/SseEmitterManager.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/web/manager/SseEmitterManager.java
@@ -2,56 +2,52 @@ package com.baedal.delivery.adapter.in.web.manager;
 
 import com.baedal.delivery.adapter.in.message.listener.RedisSubscriber;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SseEmitterManager {
 
   private final RedisSubscriber subscriber;
 
-  // TODO: owner가 하나의 store에 여러 클라이언트로 SSE 연결할 경우 storeId->List로
-  private final Map<Long, List<SseEmitter>> emitterMap = new ConcurrentHashMap<>();
+  private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
 
   public synchronized void addEmitter(Long storeId, SseEmitter emitter) {
-    emitterMap.computeIfAbsent(storeId, id -> new CopyOnWriteArrayList<>()).add(emitter);
+    if (!emitterMap.containsKey(storeId)) {
+      emitterMap.put(storeId, emitter);
 
-    if (emitterMap.get(storeId).size() == 1) {
       subscriber.subscribe(storeId);
-    }
 
-    emitter.onCompletion(() -> removeEmitter(storeId, emitter));
-    emitter.onTimeout(() -> removeEmitter(storeId, emitter));
+      emitter.onCompletion(() -> removeEmitter(storeId, "completion"));
+      emitter.onTimeout(() -> removeEmitter(storeId, "timeout"));
+    }
   }
 
-  public synchronized void removeEmitter(Long storeId, SseEmitter emitter) {
-    List<SseEmitter> emitters = emitterMap.get(storeId);
-    if (emitters != null) {
-      emitters.remove(emitter);
-      if (emitters.isEmpty()) {
-        emitterMap.remove(storeId);
-        subscriber.unsubscribe(storeId);
-      }
+  public synchronized void removeEmitter(Long storeId, String reason) {
+    SseEmitter emitter = emitterMap.get(storeId);
+    if (emitter != null) {
+      emitterMap.remove(storeId);
+      subscriber.unsubscribe(storeId);
     }
+    log.debug("Removing emitter {}", reason);
   }
 
   public void sendToClients(Long storeId, String message) {
-    List<SseEmitter> emitters = emitterMap.get(storeId);
-    if (emitters == null) return;
+    SseEmitter emitter = emitterMap.get(storeId);
+    if (emitter == null) {
+      return;
+    }
 
-    for (SseEmitter emitter : emitters) {
-      try {
-        emitter.send(SseEmitter.event().name("delivery-update").data(message));
-      } catch (IOException e) {
-        removeEmitter(storeId, emitter);
-      }
+    try {
+      emitter.send(SseEmitter.event().name("delivery-update").data(message));
+    } catch (IOException e) {
+      removeEmitter(storeId, e.toString());
     }
   }
-
 }

--- a/src/main/java/com/baedal/delivery/adapter/in/web/manager/SseEmitterManager.java
+++ b/src/main/java/com/baedal/delivery/adapter/in/web/manager/SseEmitterManager.java
@@ -1,0 +1,57 @@
+package com.baedal.delivery.adapter.in.web.manager;
+
+import com.baedal.delivery.adapter.in.message.listener.RedisSubscriber;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+@RequiredArgsConstructor
+public class SseEmitterManager {
+
+  private final RedisSubscriber subscriber;
+
+  // TODO: owner가 하나의 store에 여러 클라이언트로 SSE 연결할 경우 storeId->List로
+  private final Map<Long, List<SseEmitter>> emitterMap = new ConcurrentHashMap<>();
+
+  public synchronized void addEmitter(Long storeId, SseEmitter emitter) {
+    emitterMap.computeIfAbsent(storeId, id -> new CopyOnWriteArrayList<>()).add(emitter);
+
+    if (emitterMap.get(storeId).size() == 1) {
+      subscriber.subscribe(storeId);
+    }
+
+    emitter.onCompletion(() -> removeEmitter(storeId, emitter));
+    emitter.onTimeout(() -> removeEmitter(storeId, emitter));
+  }
+
+  public synchronized void removeEmitter(Long storeId, SseEmitter emitter) {
+    List<SseEmitter> emitters = emitterMap.get(storeId);
+    if (emitters != null) {
+      emitters.remove(emitter);
+      if (emitters.isEmpty()) {
+        emitterMap.remove(storeId);
+        subscriber.unsubscribe(storeId);
+      }
+    }
+  }
+
+  public void sendToClients(Long storeId, String message) {
+    List<SseEmitter> emitters = emitterMap.get(storeId);
+    if (emitters == null) return;
+
+    for (SseEmitter emitter : emitters) {
+      try {
+        emitter.send(SseEmitter.event().name("delivery-update").data(message));
+      } catch (IOException e) {
+        removeEmitter(storeId, emitter);
+      }
+    }
+  }
+
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/cache/DeliveryCacheAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/cache/DeliveryCacheAdapter.java
@@ -1,0 +1,66 @@
+package com.baedal.delivery.adapter.out.cache;
+
+import com.baedal.delivery.adapter.out.cache.template.RedisKeyValueTemplate;
+import com.baedal.delivery.adapter.out.cache.template.RedisSetTemplate;
+import com.baedal.delivery.application.port.out.DeliveryCachePort;
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryCacheAdapter implements DeliveryCachePort {
+
+  private final RedisKeyValueTemplate keyValueTemplate;
+
+  private final RedisSetTemplate setTemplate;
+
+  @Value("${redis.key-format.delivery-status.key}")
+  private String deliveryKeyFormat;
+
+  @Value("${redis.key-format.delivery-status.ttl}")
+  private Duration deliveryTtl;
+
+  @Value("${redis.key-format.delivery-store.key}")
+  private String deliveryStoreKeyFormat;
+
+  @Value("${redis.key-format.delivery-store.ttl}")
+  private Duration deliveryStoreTtl;
+
+  public void saveStatus(Long deliveryId, Long storeId, DeliveryStatus deliveryStatus) {
+    String deliveryStatusKey = String.format(deliveryKeyFormat, deliveryId);
+    String deliveryStoreKey = String.format(deliveryStoreKeyFormat, storeId);
+
+    // if Delivered, remove cache
+    if (deliveryStatus.isDelivered()) {
+      keyValueTemplate.delete(deliveryStatusKey);
+      setTemplate.remove(deliveryStatusKey, deliveryId);
+      return;
+    }
+
+    // deliveryId에 해당하는 배달 상태 캐시
+    keyValueTemplate.set(deliveryStatusKey, deliveryStatus, deliveryTtl);
+
+    // storeId에 해당하는 Set of deliveryIds 캐시
+    setTemplate.add(deliveryStoreKey, deliveryId, deliveryStoreTtl);
+  }
+
+  public Optional<DeliveryStatus> findByDeliveryId(Long deliveryId) {
+    String deliveryStatusKey = String.format(deliveryKeyFormat, deliveryId);
+    return keyValueTemplate.get(deliveryStatusKey, DeliveryStatus.class);
+  }
+
+  public Set<Long> findAllByStoreId(Long storeId) {
+    String deliveryStoreKey = String.format(deliveryStoreKeyFormat, storeId);
+    Set<Object> members = setTemplate.members(deliveryStoreKey);
+
+    return members.stream()
+        .map(o -> Long.valueOf(o.toString()))
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/cache/template/RedisKeyValueTemplate.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/cache/template/RedisKeyValueTemplate.java
@@ -1,0 +1,30 @@
+package com.baedal.delivery.adapter.out.cache.template;
+
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisKeyValueTemplate {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public void set(String key, Object value, Duration ttl) {
+    redisTemplate.opsForValue().set(key, value, ttl);
+  }
+
+  public <T> Optional<T> get(String key, Class<T> clazz) {
+    Object value = redisTemplate.opsForValue().get(key);
+    if (clazz.isInstance(value)) {
+      return Optional.of(clazz.cast(value));
+    }
+    return Optional.empty();
+  }
+
+  public void delete(String key) {
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/cache/template/RedisSetTemplate.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/cache/template/RedisSetTemplate.java
@@ -1,0 +1,46 @@
+package com.baedal.delivery.adapter.out.cache.template;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisSetTemplate {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public void add(String key, Object value, Duration ttl) {
+    redisTemplate.opsForSet().add(key, value);
+    redisTemplate.expire(key, ttl);
+  }
+
+  public void addAll(String key, Collection<?> values, Duration ttl) {
+    if (values != null && !values.isEmpty()) {
+      redisTemplate.opsForSet().add(key, values.toArray());
+    }
+    redisTemplate.expire(key, ttl);
+  }
+
+  public void remove(String key, Object value) {
+    redisTemplate.opsForSet().remove(key, value);
+  }
+
+  public Set<Object> members(String key) {
+    Set<Object> result = redisTemplate.opsForSet().members(key);
+    return result != null ? result : Collections.emptySet();
+  }
+
+  public boolean isMember(String key, Object value) {
+    Boolean result = redisTemplate.opsForSet().isMember(key, value);
+    return Boolean.TRUE.equals(result);
+  }
+
+  public void delete(String key) {
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/event/EventPublisherAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/event/EventPublisherAdapter.java
@@ -1,0 +1,21 @@
+package com.baedal.delivery.adapter.out.event;
+
+import com.baedal.delivery.adapter.out.event.publisher.SpringEventPublisher;
+import com.baedal.delivery.application.port.out.DeliveryEventPublisherPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EventPublisherAdapter implements DeliveryEventPublisherPort {
+
+  private final SpringEventPublisher springEventPublisher;
+
+  @Override
+  public void publishEvent(Object event) {
+    log.debug("publish event:[{}]", event.getClass().getName());
+    springEventPublisher.publishEvent(event);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/event/publisher/SpringEventPublisher.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/event/publisher/SpringEventPublisher.java
@@ -1,0 +1,16 @@
+package com.baedal.delivery.adapter.out.event.publisher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringEventPublisher {
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  public void publishEvent(Object event) {
+    eventPublisher.publishEvent(event);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/message/DeliveryMessagePublisherAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/message/DeliveryMessagePublisherAdapter.java
@@ -1,0 +1,28 @@
+package com.baedal.delivery.adapter.out.message;
+
+import com.baedal.delivery.adapter.out.message.publisher.RedisPublisher;
+import com.baedal.delivery.application.port.out.DeliveryMessagePublisherPort;
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import com.baedal.delivery.util.ObjectMapperUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryMessagePublisherAdapter implements DeliveryMessagePublisherPort {
+
+  private final RedisPublisher redisPublisher;
+
+  @Value("${redis.channel-format.delivery-update}")
+  private String channelFormat;
+
+  public void deliveryStatusUpdate(Long storeId, DeliveryStatus status) {
+    String channelName = String.format(channelFormat, storeId);
+    ChannelTopic topic = new ChannelTopic(channelName);
+    String message = ObjectMapperUtil.toJson(status);
+
+    redisPublisher.publish(topic, message);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/message/DeliveryMessagePublisherAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/message/DeliveryMessagePublisherAdapter.java
@@ -2,12 +2,10 @@ package com.baedal.delivery.adapter.out.message;
 
 import com.baedal.delivery.adapter.out.message.publisher.RedisPublisher;
 import com.baedal.delivery.application.port.out.DeliveryMessagePublisherPort;
-import com.baedal.delivery.domain.model.DeliveryStatus;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import com.baedal.delivery.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,9 +19,8 @@ public class DeliveryMessagePublisherAdapter implements DeliveryMessagePublisher
 
   public void deliveryStatusUpdate(Long storeId, UpdateDeliveryStatus model) {
     String channelName = String.format(channelFormat, storeId);
-    ChannelTopic topic = new ChannelTopic(channelName);
     String message = ObjectMapperUtil.toJson(model);
 
-    redisPublisher.publish(topic, message);
+    redisPublisher.publish(channelName, message);
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/message/DeliveryMessagePublisherAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/message/DeliveryMessagePublisherAdapter.java
@@ -3,6 +3,7 @@ package com.baedal.delivery.adapter.out.message;
 import com.baedal.delivery.adapter.out.message.publisher.RedisPublisher;
 import com.baedal.delivery.application.port.out.DeliveryMessagePublisherPort;
 import com.baedal.delivery.domain.model.DeliveryStatus;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import com.baedal.delivery.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,10 +19,10 @@ public class DeliveryMessagePublisherAdapter implements DeliveryMessagePublisher
   @Value("${redis.channel-format.delivery-update}")
   private String channelFormat;
 
-  public void deliveryStatusUpdate(Long storeId, DeliveryStatus status) {
+  public void deliveryStatusUpdate(Long storeId, UpdateDeliveryStatus model) {
     String channelName = String.format(channelFormat, storeId);
     ChannelTopic topic = new ChannelTopic(channelName);
-    String message = ObjectMapperUtil.toJson(status);
+    String message = ObjectMapperUtil.toJson(model);
 
     redisPublisher.publish(topic, message);
   }

--- a/src/main/java/com/baedal/delivery/adapter/out/message/publisher/RedisPublisher.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/message/publisher/RedisPublisher.java
@@ -1,0 +1,19 @@
+package com.baedal.delivery.adapter.out.message.publisher;
+
+import com.baedal.delivery.util.ObjectMapperUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisPublisher {
+
+  private final RedisTemplate<String, Object> template;
+
+  public void publish(ChannelTopic topic, Object message) {
+    String json = ObjectMapperUtil.toJson(message);
+    template.convertAndSend(topic.getTopic(), json);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/message/publisher/RedisPublisher.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/message/publisher/RedisPublisher.java
@@ -3,7 +3,6 @@ package com.baedal.delivery.adapter.out.message.publisher;
 import com.baedal.delivery.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,8 +11,8 @@ public class RedisPublisher {
 
   private final RedisTemplate<String, Object> template;
 
-  public void publish(ChannelTopic topic, Object message) {
+  public void publish(String channelName, Object message) {
     String json = ObjectMapperUtil.toJson(message);
-    template.convertAndSend(topic.getTopic(), json);
+    template.convertAndSend(channelName, json);
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
@@ -10,6 +10,8 @@ import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
 import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -42,5 +44,18 @@ public class DeliveryRepositoryAdapter implements DeliveryRepositoryPort {
   public Delivery findById(long id) {
     DeliveryEntity entity = reader.readDelivery(id);
     return mapper.toDomain(entity);
+  }
+
+  public List<Delivery> findAllByIds(Collection<Long> ids) {
+    return reader.readAllByIds(ids).stream()
+        .map(mapper::toDomain)
+        .toList();
+  }
+
+  public List<UpdateDeliveryStatus> findAllValidDeliveriesByStoreId(Long storeId) {
+    List<DeliveryEntity> entities = reader.readAllValidDeliveries(storeId);
+    return entities.stream()
+        .map(mapper::toUpdateDeliveryStatus)
+        .toList();
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
@@ -3,10 +3,12 @@ package com.baedal.delivery.adapter.out.persistence.adapters;
 import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
 import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
 import com.baedal.delivery.adapter.out.persistence.manager.DeliveryCreator;
+import com.baedal.delivery.adapter.out.persistence.manager.DeliveryReader;
 import com.baedal.delivery.adapter.out.persistence.manager.DeliveryUpdater;
 import com.baedal.delivery.adapter.out.persistence.mapper.DeliveryPersistenceMapper;
 import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
 import com.baedal.delivery.domain.model.CreateDelivery;
+import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,21 +17,30 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeliveryRepositoryAdapter implements DeliveryRepositoryPort {
 
-  private final DeliveryPersistenceMapper deliveryMapper;
+  private final DeliveryPersistenceMapper mapper;
 
-  private final DeliveryUpdater deliveryUpdater;
+  private final DeliveryUpdater updater;
 
   private final DeliveryCreator creator;
 
+  private final DeliveryReader reader;
+
   @Override
   public void updateStatus(UpdateDeliveryStatus updateDeliveryStatus) {
-    DeliveryEntityStatus status = deliveryMapper.toEntityStatus(updateDeliveryStatus.getStatus());
-    deliveryUpdater.updateStatus(updateDeliveryStatus.getId(), status);
+    DeliveryEntityStatus status = mapper.toEntityStatus(updateDeliveryStatus.getStatus());
+    updater.updateStatus(updateDeliveryStatus.getId(), status);
   }
 
   @Override
-  public long createDelivery(CreateDelivery createDelivery) {
-    DeliveryEntity entity = deliveryMapper.toEntity(createDelivery);
-    return creator.create(entity);
+  public Delivery createDelivery(CreateDelivery createDelivery) {
+    DeliveryEntity entity = mapper.toEntity(createDelivery);
+    entity = creator.create(entity);
+    return mapper.toDomain(entity);
+  }
+
+  @Override
+  public Delivery findById(long id) {
+    DeliveryEntity entity = reader.readDelivery(id);
+    return mapper.toDomain(entity);
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.baedal.delivery.adapter.out.persistence.adapters;
+
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import com.baedal.delivery.adapter.out.persistence.manager.DeliveryUpdater;
+import com.baedal.delivery.adapter.out.persistence.mapper.DeliveryPersistenceMapper;
+import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryRepositoryAdapter implements DeliveryRepositoryPort {
+
+  private final DeliveryPersistenceMapper deliveryMapper;
+  private final DeliveryUpdater deliveryUpdater;
+
+  @Override
+  public void updateStatus(UpdateDeliveryStatus updateDeliveryStatus) {
+    DeliveryEntityStatus status = deliveryMapper.toEntityStatus(updateDeliveryStatus.getStatus());
+    deliveryUpdater.updateStatus(updateDeliveryStatus.getId(), status);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/adapters/DeliveryRepositoryAdapter.java
@@ -1,9 +1,12 @@
 package com.baedal.delivery.adapter.out.persistence.adapters;
 
+import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
 import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import com.baedal.delivery.adapter.out.persistence.manager.DeliveryCreator;
 import com.baedal.delivery.adapter.out.persistence.manager.DeliveryUpdater;
 import com.baedal.delivery.adapter.out.persistence.mapper.DeliveryPersistenceMapper;
 import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
+import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,11 +16,20 @@ import org.springframework.stereotype.Component;
 public class DeliveryRepositoryAdapter implements DeliveryRepositoryPort {
 
   private final DeliveryPersistenceMapper deliveryMapper;
+
   private final DeliveryUpdater deliveryUpdater;
+
+  private final DeliveryCreator creator;
 
   @Override
   public void updateStatus(UpdateDeliveryStatus updateDeliveryStatus) {
     DeliveryEntityStatus status = deliveryMapper.toEntityStatus(updateDeliveryStatus.getStatus());
     deliveryUpdater.updateStatus(updateDeliveryStatus.getId(), status);
+  }
+
+  @Override
+  public long createDelivery(CreateDelivery createDelivery) {
+    DeliveryEntity entity = deliveryMapper.toEntity(createDelivery);
+    return creator.create(entity);
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
@@ -9,14 +9,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "deliverys")
+@Table(name = "delivery")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeliveryEntity {
 
   @Id
@@ -24,6 +24,27 @@ public class DeliveryEntity {
   private Long id;
 
   @Column(nullable = false)
+  private Long orderId;
+
+  @Column(nullable = false)
+  private Long storedId;
+
+  @Column(nullable = false)
+  private Long customerId;
+
+  @Column(nullable = true)
+  private Long riderId;
+
+  @Column(nullable = false)
   private DeliveryEntityStatus status;
 
+  @Builder
+  public DeliveryEntity(Long orderId, Long storedId, Long customerId, Long riderId,
+      DeliveryEntityStatus status) {
+    this.orderId = orderId;
+    this.storedId = storedId;
+    this.customerId = customerId;
+    this.riderId = riderId;
+    this.status = status;
+  }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
@@ -1,0 +1,29 @@
+package com.baedal.delivery.adapter.out.persistence.entity;
+
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "deliverys")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private DeliveryEntityStatus status;
+
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/entity/DeliveryEntity.java
@@ -3,6 +3,8 @@ package com.baedal.delivery.adapter.out.persistence.entity;
 import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -35,6 +37,7 @@ public class DeliveryEntity {
   @Column(nullable = true)
   private Long riderId;
 
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private DeliveryEntityStatus status;
 

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/enums/DeliveryEntityStatus.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/enums/DeliveryEntityStatus.java
@@ -1,5 +1,5 @@
 package com.baedal.delivery.adapter.out.persistence.enums;
 
 public enum DeliveryEntityStatus {
-  PENDING, DELIVERING, DELIVERED;
+  PENDING, DELIVERING, DELIVERED
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/enums/DeliveryEntityStatus.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/enums/DeliveryEntityStatus.java
@@ -1,0 +1,5 @@
+package com.baedal.delivery.adapter.out.persistence.enums;
+
+public enum DeliveryEntityStatus {
+  PENDING, DELIVERING, DELIVERED;
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryCreator.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryCreator.java
@@ -1,0 +1,18 @@
+package com.baedal.delivery.adapter.out.persistence.manager;
+
+import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
+import com.baedal.delivery.adapter.out.persistence.repository.DeliveryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryCreator {
+
+  private final DeliveryJpaRepository repository;
+
+  public Long create(DeliveryEntity entity) {
+    return repository.save(entity)
+        .getId();
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryReader.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryReader.java
@@ -1,7 +1,10 @@
 package com.baedal.delivery.adapter.out.persistence.manager;
 
 import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
 import com.baedal.delivery.adapter.out.persistence.repository.DeliveryJpaRepository;
+import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,5 +17,13 @@ public class DeliveryReader {
   public DeliveryEntity readDelivery(Long id) {
     return repository.findById(id)
         .orElseThrow(() -> new RuntimeException("No delivery found with id: " + id));
+  }
+
+  public List<DeliveryEntity> readAllValidDeliveries(Long storeId) {
+    return repository.findByStoredIdAndStatusNot(storeId, DeliveryEntityStatus.DELIVERED);
+  }
+
+  public List<DeliveryEntity> readAllByIds(Collection<Long> ids) {
+    return repository.findAllById(ids);
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryReader.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryReader.java
@@ -7,11 +7,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class DeliveryCreator {
+public class DeliveryReader {
 
   private final DeliveryJpaRepository repository;
 
-  public DeliveryEntity create(DeliveryEntity entity) {
-    return repository.save(entity);
+  public DeliveryEntity readDelivery(Long id) {
+    return repository.findById(id)
+        .orElseThrow(() -> new RuntimeException("No delivery found with id: " + id));
   }
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryUpdater.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/manager/DeliveryUpdater.java
@@ -1,0 +1,17 @@
+package com.baedal.delivery.adapter.out.persistence.manager;
+
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import com.baedal.delivery.adapter.out.persistence.repository.DeliveryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryUpdater {
+
+  private final DeliveryJpaRepository deliveryJpaRepository;
+
+  public void updateStatus(Long id, DeliveryEntityStatus status) {
+    deliveryJpaRepository.updateStatus(id, status);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
@@ -1,6 +1,8 @@
 package com.baedal.delivery.adapter.out.persistence.mapper;
 
+import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
 import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.DeliveryStatus;
 import org.mapstruct.Mapper;
 
@@ -8,4 +10,6 @@ import org.mapstruct.Mapper;
 public interface DeliveryPersistenceMapper {
 
   DeliveryEntityStatus toEntityStatus(DeliveryStatus status);
+
+  DeliveryEntity toEntity(CreateDelivery model);
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
@@ -5,6 +5,7 @@ import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
 import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.DeliveryStatus;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -15,4 +16,6 @@ public interface DeliveryPersistenceMapper {
   DeliveryEntity toEntity(CreateDelivery model);
 
   Delivery toDomain(DeliveryEntity entity);
+
+  UpdateDeliveryStatus toUpdateDeliveryStatus(DeliveryEntity entity);
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
@@ -1,0 +1,11 @@
+package com.baedal.delivery.adapter.out.persistence.mapper;
+
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DeliveryPersistenceMapper {
+
+  DeliveryEntityStatus toEntityStatus(DeliveryStatus status);
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapper.java
@@ -3,6 +3,7 @@ package com.baedal.delivery.adapter.out.persistence.mapper;
 import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
 import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
 import com.baedal.delivery.domain.model.CreateDelivery;
+import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.DeliveryStatus;
 import org.mapstruct.Mapper;
 
@@ -12,4 +13,6 @@ public interface DeliveryPersistenceMapper {
   DeliveryEntityStatus toEntityStatus(DeliveryStatus status);
 
   DeliveryEntity toEntity(CreateDelivery model);
+
+  Delivery toDomain(DeliveryEntity entity);
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/repository/DeliveryJpaRepository.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/repository/DeliveryJpaRepository.java
@@ -1,0 +1,16 @@
+package com.baedal.delivery.adapter.out.persistence.repository;
+
+import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DeliveryJpaRepository extends JpaRepository<DeliveryEntity, Long> {
+
+  @Modifying
+  @Query("UPDATE DeliveryEntity d SET d.status = :status WHERE d.id = :id")
+  void updateStatus(@Param("id") Long id, @Param("status") DeliveryEntityStatus status);
+
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/persistence/repository/DeliveryJpaRepository.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/persistence/repository/DeliveryJpaRepository.java
@@ -2,6 +2,7 @@ package com.baedal.delivery.adapter.out.persistence.repository;
 
 import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
 import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,5 @@ public interface DeliveryJpaRepository extends JpaRepository<DeliveryEntity, Lon
   @Query("UPDATE DeliveryEntity d SET d.status = :status WHERE d.id = :id")
   void updateStatus(@Param("id") Long id, @Param("status") DeliveryEntityStatus status);
 
+  List<DeliveryEntity> findByStoredIdAndStatusNot(Long storedId, DeliveryEntityStatus status);
 }

--- a/src/main/java/com/baedal/delivery/adapter/out/web/DeliveryStatusSenderAdapter.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/web/DeliveryStatusSenderAdapter.java
@@ -1,0 +1,18 @@
+package com.baedal.delivery.adapter.out.web;
+
+import com.baedal.delivery.adapter.out.web.manager.StoreSseEmitterManager;
+import com.baedal.delivery.application.port.out.DeliveryStatusSenderPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryStatusSenderAdapter implements DeliveryStatusSenderPort {
+
+  private final StoreSseEmitterManager emitterManager;
+
+  @Override
+  public void sendToStore(Long storeId, String payload) {
+    emitterManager.sendToClients(storeId, payload);
+  }
+}

--- a/src/main/java/com/baedal/delivery/adapter/out/web/manager/StoreSseEmitterManager.java
+++ b/src/main/java/com/baedal/delivery/adapter/out/web/manager/StoreSseEmitterManager.java
@@ -1,6 +1,6 @@
-package com.baedal.delivery.adapter.in.web.manager;
+package com.baedal.delivery.adapter.out.web.manager;
 
-import com.baedal.delivery.adapter.in.message.listener.RedisSubscriber;
+import com.baedal.delivery.application.port.out.DeliveryStatusSubscriptionPort;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -12,9 +12,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class SseEmitterManager {
+public class StoreSseEmitterManager {
 
-  private final RedisSubscriber subscriber;
+  private final DeliveryStatusSubscriptionPort subscriptionPort;
 
   private final Map<Long, SseEmitter> emitterMap = new ConcurrentHashMap<>();
 
@@ -22,7 +22,7 @@ public class SseEmitterManager {
     if (!emitterMap.containsKey(storeId)) {
       emitterMap.put(storeId, emitter);
 
-      subscriber.subscribe(storeId);
+      subscriptionPort.subscribe(storeId);
 
       emitter.onCompletion(() -> removeEmitter(storeId, "completion"));
       emitter.onTimeout(() -> removeEmitter(storeId, "timeout"));
@@ -33,7 +33,7 @@ public class SseEmitterManager {
     SseEmitter emitter = emitterMap.get(storeId);
     if (emitter != null) {
       emitterMap.remove(storeId);
-      subscriber.unsubscribe(storeId);
+      subscriptionPort.unsubscribe(storeId);
     }
     log.debug("Removing emitter {}", reason);
   }

--- a/src/main/java/com/baedal/delivery/application/command/UpdateDeliveryStatusCommand.java
+++ b/src/main/java/com/baedal/delivery/application/command/UpdateDeliveryStatusCommand.java
@@ -8,6 +8,7 @@ public class UpdateDeliveryStatusCommand {
   @Builder
   @Getter
   public static class Request {
+
     private Long deliveryId;
     private String status;
   }

--- a/src/main/java/com/baedal/delivery/application/command/UpdateDeliveryStatusCommand.java
+++ b/src/main/java/com/baedal/delivery/application/command/UpdateDeliveryStatusCommand.java
@@ -1,0 +1,15 @@
+package com.baedal.delivery.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class UpdateDeliveryStatusCommand {
+
+  @Builder
+  @Getter
+  public static class Request {
+    private Long deliveryId;
+    private String status;
+  }
+
+}

--- a/src/main/java/com/baedal/delivery/application/event/DeliveryCreatedEvent.java
+++ b/src/main/java/com/baedal/delivery/application/event/DeliveryCreatedEvent.java
@@ -1,0 +1,20 @@
+package com.baedal.delivery.application.event;
+
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliveryCreatedEvent {
+
+  private Long deliveryId;
+
+  private Long orderId;
+
+  private Long storeId;
+
+  private Long customerId;
+
+  private DeliveryStatus status;
+}

--- a/src/main/java/com/baedal/delivery/application/event/DeliveryStatusUpdatedEvent.java
+++ b/src/main/java/com/baedal/delivery/application/event/DeliveryStatusUpdatedEvent.java
@@ -1,0 +1,22 @@
+package com.baedal.delivery.application.event;
+
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliveryStatusUpdatedEvent {
+
+  private Long deliveryId;
+
+  private Long orderId;
+
+  private Long storeId;
+
+  private Long customerId;
+
+  private Long riderId;
+
+  private DeliveryStatus status;
+}

--- a/src/main/java/com/baedal/delivery/application/mapper/DeliveryApplicationMapper.java
+++ b/src/main/java/com/baedal/delivery/application/mapper/DeliveryApplicationMapper.java
@@ -2,6 +2,7 @@ package com.baedal.delivery.application.mapper;
 
 import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
 import com.baedal.delivery.domain.model.CreateDelivery;
+import com.baedal.delivery.domain.model.DeliveryStatus;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -11,6 +12,8 @@ public interface DeliveryApplicationMapper {
 
   @Mapping(target = "id", source = "deliveryId")
   UpdateDeliveryStatus updateDeliveryStatus(UpdateDeliveryStatusCommand.Request req);
+
+  UpdateDeliveryStatus updateDeliveryStatus(Long id, DeliveryStatus status);
 
   CreateDelivery createDelivery(Long storeId, Long orderId, Long customerId);
 }

--- a/src/main/java/com/baedal/delivery/application/mapper/DeliveryApplicationMapper.java
+++ b/src/main/java/com/baedal/delivery/application/mapper/DeliveryApplicationMapper.java
@@ -1,0 +1,11 @@
+package com.baedal.delivery.application.mapper;
+
+import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DeliveryApplicationMapper {
+
+  UpdateDeliveryStatus updateDeliveryStatus(UpdateDeliveryStatusCommand.Request req);
+}

--- a/src/main/java/com/baedal/delivery/application/mapper/DeliveryApplicationMapper.java
+++ b/src/main/java/com/baedal/delivery/application/mapper/DeliveryApplicationMapper.java
@@ -1,11 +1,16 @@
 package com.baedal.delivery.application.mapper;
 
 import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
+import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface DeliveryApplicationMapper {
 
+  @Mapping(target = "id", source = "deliveryId")
   UpdateDeliveryStatus updateDeliveryStatus(UpdateDeliveryStatusCommand.Request req);
+
+  CreateDelivery createDelivery(Long storeId, Long orderId, Long customerId);
 }

--- a/src/main/java/com/baedal/delivery/application/mapper/DeliveryEventMapper.java
+++ b/src/main/java/com/baedal/delivery/application/mapper/DeliveryEventMapper.java
@@ -1,0 +1,17 @@
+package com.baedal.delivery.application.mapper;
+
+import com.baedal.delivery.application.event.DeliveryCreatedEvent;
+import com.baedal.delivery.application.event.DeliveryStatusUpdatedEvent;
+import com.baedal.delivery.domain.model.Delivery;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface DeliveryEventMapper {
+
+  @Mapping(target = "deliveryId", source = "id")
+  DeliveryStatusUpdatedEvent toDeliveryStatusUpdatedEvent(Delivery model);
+
+  @Mapping(target = "deliveryId", source = "id")
+  DeliveryCreatedEvent toDeliveryCreatedEvent(Delivery model);
+}

--- a/src/main/java/com/baedal/delivery/application/port/in/DeliveryUseCase.java
+++ b/src/main/java/com/baedal/delivery/application/port/in/DeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.baedal.delivery.application.port.in;
+
+import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
+
+public interface DeliveryUseCase {
+
+  void updateDeliveryStatus(UpdateDeliveryStatusCommand.Request req);
+}

--- a/src/main/java/com/baedal/delivery/application/port/in/DeliveryUseCase.java
+++ b/src/main/java/com/baedal/delivery/application/port/in/DeliveryUseCase.java
@@ -5,4 +5,6 @@ import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand;
 public interface DeliveryUseCase {
 
   void updateDeliveryStatus(UpdateDeliveryStatusCommand.Request req);
+
+  long createDelivery(Long storeId, Long orderId, Long customerId);
 }

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryCachePort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryCachePort.java
@@ -1,0 +1,14 @@
+package com.baedal.delivery.application.port.out;
+
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import java.util.Optional;
+import java.util.Set;
+
+public interface DeliveryCachePort {
+
+  void saveStatus(Long deliveryId, Long storeId, DeliveryStatus deliveryStatus);
+
+  Optional<DeliveryStatus> findByDeliveryId(Long deliveryId);
+
+  Set<Long> findAllByStoreId(Long storeId);
+}

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryEventPublisherPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryEventPublisherPort.java
@@ -1,0 +1,6 @@
+package com.baedal.delivery.application.port.out;
+
+public interface DeliveryEventPublisherPort {
+
+  void publishEvent(Object event);
+}

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryMessagePublisherPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryMessagePublisherPort.java
@@ -1,0 +1,8 @@
+package com.baedal.delivery.application.port.out;
+
+import com.baedal.delivery.domain.model.DeliveryStatus;
+
+public interface DeliveryMessagePublisherPort {
+
+  void deliveryStatusUpdate(Long storeId, DeliveryStatus status);
+}

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryMessagePublisherPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryMessagePublisherPort.java
@@ -1,8 +1,8 @@
 package com.baedal.delivery.application.port.out;
 
-import com.baedal.delivery.domain.model.DeliveryStatus;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 
 public interface DeliveryMessagePublisherPort {
 
-  void deliveryStatusUpdate(Long storeId, DeliveryStatus status);
+  void deliveryStatusUpdate(Long storeId, UpdateDeliveryStatus model);
 }

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
@@ -1,11 +1,14 @@
 package com.baedal.delivery.application.port.out;
 
 import com.baedal.delivery.domain.model.CreateDelivery;
+import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 
 public interface DeliveryRepositoryPort {
 
   void updateStatus(UpdateDeliveryStatus updateDeliveryStatus);
 
-  long createDelivery(CreateDelivery createDelivery);
+  Delivery createDelivery(CreateDelivery createDelivery);
+
+  Delivery findById(long id);
 }

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
@@ -1,0 +1,9 @@
+package com.baedal.delivery.application.port.out;
+
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+
+public interface DeliveryRepositoryPort {
+
+  void updateStatus(UpdateDeliveryStatus updateDeliveryStatus);
+
+}

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
@@ -1,9 +1,11 @@
 package com.baedal.delivery.application.port.out;
 
+import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 
 public interface DeliveryRepositoryPort {
 
   void updateStatus(UpdateDeliveryStatus updateDeliveryStatus);
 
+  long createDelivery(CreateDelivery createDelivery);
 }

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryRepositoryPort.java
@@ -3,6 +3,8 @@ package com.baedal.delivery.application.port.out;
 import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import java.util.Collection;
+import java.util.List;
 
 public interface DeliveryRepositoryPort {
 
@@ -11,4 +13,8 @@ public interface DeliveryRepositoryPort {
   Delivery createDelivery(CreateDelivery createDelivery);
 
   Delivery findById(long id);
+
+  List<Delivery> findAllByIds(Collection<Long> ids);
+
+  List<UpdateDeliveryStatus> findAllValidDeliveriesByStoreId(Long storeId);
 }

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryStatusSenderPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryStatusSenderPort.java
@@ -1,0 +1,6 @@
+package com.baedal.delivery.application.port.out;
+
+public interface DeliveryStatusSenderPort {
+
+  void sendToStore(Long storeId, String payload);
+}

--- a/src/main/java/com/baedal/delivery/application/port/out/DeliveryStatusSubscriptionPort.java
+++ b/src/main/java/com/baedal/delivery/application/port/out/DeliveryStatusSubscriptionPort.java
@@ -1,0 +1,8 @@
+package com.baedal.delivery.application.port.out;
+
+public interface DeliveryStatusSubscriptionPort {
+
+  void subscribe(Long storeId);
+
+  void unsubscribe(Long storeId);
+}

--- a/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
+++ b/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
@@ -1,10 +1,16 @@
 package com.baedal.delivery.application.service;
 
 import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand.Request;
+import com.baedal.delivery.application.event.DeliveryCreatedEvent;
+import com.baedal.delivery.application.event.DeliveryStatusUpdatedEvent;
 import com.baedal.delivery.application.mapper.DeliveryApplicationMapper;
+import com.baedal.delivery.application.mapper.DeliveryEventMapper;
 import com.baedal.delivery.application.port.in.DeliveryUseCase;
+import com.baedal.delivery.application.port.out.DeliveryCachePort;
+import com.baedal.delivery.application.port.out.DeliveryEventPublisherPort;
 import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
 import com.baedal.delivery.domain.model.CreateDelivery;
+import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,19 +20,34 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DeliveryService implements DeliveryUseCase {
 
-  private final DeliveryApplicationMapper deliveryMapper;
-
   private final DeliveryRepositoryPort deliveryRepository;
 
-  @Override
+  private final DeliveryCachePort deliveryCachePort;
+
+  private final DeliveryEventPublisherPort eventPublisher;
+
+  private final DeliveryEventMapper eventMapper;
+
+  private final DeliveryApplicationMapper deliveryMapper;
+
+  @Transactional
   public void updateDeliveryStatus(Request req) {
-    UpdateDeliveryStatus delivery = deliveryMapper.updateDeliveryStatus(req);
-    deliveryRepository.updateStatus(delivery);
+    Delivery delivery = deliveryRepository.findById(req.getDeliveryId());
+    UpdateDeliveryStatus updateDelivery = deliveryMapper.updateDeliveryStatus(req);
+    deliveryRepository.updateStatus(updateDelivery);
+
+    DeliveryStatusUpdatedEvent event = eventMapper.toDeliveryStatusUpdatedEvent(delivery);
+    eventPublisher.publishEvent(event);
   }
 
   @Transactional
   public long createDelivery(Long storeId, Long orderId, Long customerId) {
-    CreateDelivery delivery = deliveryMapper.createDelivery(storeId, orderId, customerId);
-    return deliveryRepository.createDelivery(delivery);
+    CreateDelivery createDelivery = deliveryMapper.createDelivery(storeId, orderId, customerId);
+    Delivery delivery = deliveryRepository.createDelivery(createDelivery);
+
+    DeliveryCreatedEvent event = eventMapper.toDeliveryCreatedEvent(delivery);
+    eventPublisher.publishEvent(event);
+
+    return delivery.getId();
   }
 }

--- a/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
+++ b/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
@@ -12,7 +12,12 @@ import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
 import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +28,7 @@ public class DeliveryService implements DeliveryUseCase {
 
   private final DeliveryRepositoryPort deliveryRepository;
 
-  private final DeliveryCachePort deliveryCachePort;
+  private final DeliveryCachePort cachePort;
 
   private final DeliveryEventPublisherPort eventPublisher;
 
@@ -50,5 +55,46 @@ public class DeliveryService implements DeliveryUseCase {
     eventPublisher.publishEvent(event);
 
     return delivery.getId();
+  }
+
+  // FIXME: cache 조회 로직을 분리?
+  public List<UpdateDeliveryStatus> getStoresDeliveryStatus(Long storeId) {
+    Set<Long> deliveryIds = cachePort.findAllByStoreId(storeId);
+
+    if (deliveryIds.isEmpty()) { // 1. cache miss
+      return deliveryRepository.findAllValidDeliveriesByStoreId(storeId);
+    }
+
+    // 2. cache hit[store set]
+    Map<Long, UpdateDeliveryStatus> cached = new HashMap<>();
+    Set<Long> cacheMissed = new HashSet<>();
+
+    for (Long deliveryId : deliveryIds) {
+      cachePort.findByDeliveryId(deliveryId)
+          .map(status -> deliveryMapper.updateDeliveryStatus(deliveryId, status))
+          .ifPresentOrElse(
+              status -> cached.put(deliveryId, status),
+              () -> cacheMissed.add(deliveryId)
+          );
+    }
+
+    if (!cacheMissed.isEmpty()) { // 3. cache miss[delivery status]
+      List<Delivery> cacheMissedDeliveries =
+          deliveryRepository.findAllByIds(cacheMissed);
+
+      for (Delivery delivery : cacheMissedDeliveries) {
+        UpdateDeliveryStatus status = deliveryMapper.updateDeliveryStatus(delivery.getId(),
+            delivery.getStatus());
+        cached.put(delivery.getId(), status);
+
+        // 캐시 업데이트
+        cachePort.saveStatus(delivery.getId(), storeId, status.getStatus());
+      }
+    }
+
+    return deliveryIds.stream()
+        .map(cached::get)
+        .filter(Objects::nonNull)
+        .toList();
   }
 }

--- a/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
+++ b/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
@@ -4,21 +4,29 @@ import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand.Reque
 import com.baedal.delivery.application.mapper.DeliveryApplicationMapper;
 import com.baedal.delivery.application.port.in.DeliveryUseCase;
 import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
+import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class DeliveryService implements DeliveryUseCase {
 
   private final DeliveryApplicationMapper deliveryMapper;
+
   private final DeliveryRepositoryPort deliveryRepository;
+
   @Override
   public void updateDeliveryStatus(Request req) {
-
     UpdateDeliveryStatus delivery = deliveryMapper.updateDeliveryStatus(req);
     deliveryRepository.updateStatus(delivery);
+  }
 
+  @Transactional
+  public long createDelivery(Long storeId, Long orderId, Long customerId) {
+    CreateDelivery delivery = deliveryMapper.createDelivery(storeId, orderId, customerId);
+    return deliveryRepository.createDelivery(delivery);
   }
 }

--- a/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
+++ b/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
@@ -1,0 +1,24 @@
+package com.baedal.delivery.application.service;
+
+import com.baedal.delivery.application.command.UpdateDeliveryStatusCommand.Request;
+import com.baedal.delivery.application.mapper.DeliveryApplicationMapper;
+import com.baedal.delivery.application.port.in.DeliveryUseCase;
+import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService implements DeliveryUseCase {
+
+  private final DeliveryApplicationMapper deliveryMapper;
+  private final DeliveryRepositoryPort deliveryRepository;
+  @Override
+  public void updateDeliveryStatus(Request req) {
+
+    UpdateDeliveryStatus delivery = deliveryMapper.updateDeliveryStatus(req);
+    deliveryRepository.updateStatus(delivery);
+
+  }
+}

--- a/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
+++ b/src/main/java/com/baedal/delivery/application/service/DeliveryService.java
@@ -12,6 +12,7 @@ import com.baedal.delivery.application.port.out.DeliveryRepositoryPort;
 import com.baedal.delivery.domain.model.CreateDelivery;
 import com.baedal.delivery.domain.model.Delivery;
 import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/baedal/delivery/application/service/DeliveryStatusPushService.java
+++ b/src/main/java/com/baedal/delivery/application/service/DeliveryStatusPushService.java
@@ -1,0 +1,16 @@
+package com.baedal.delivery.application.service;
+
+import com.baedal.delivery.application.port.out.DeliveryStatusSenderPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryStatusPushService {
+
+  private final DeliveryStatusSenderPort statusSenderPort;
+
+  public void pushDeliveryStatus(Long storeId, String payload) {
+    statusSenderPort.sendToStore(storeId, payload);
+  }
+}

--- a/src/main/java/com/baedal/delivery/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/baedal/delivery/config/KafkaConsumerConfig.java
@@ -1,0 +1,37 @@
+package com.baedal.delivery.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+  @Value("${spring.kafka.producer.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public ConsumerFactory<String, Object> consumerFactory() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    return new DefaultKafkaConsumerFactory<>(properties);
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory());
+    return factory;
+  }
+}

--- a/src/main/java/com/baedal/delivery/config/KafkaProducerConfig.java
+++ b/src/main/java/com/baedal/delivery/config/KafkaProducerConfig.java
@@ -1,0 +1,40 @@
+package com.baedal.delivery.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+
+  @Value("${spring.kafka.producer.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public KafkaTemplate<String, String> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+
+  @Bean
+  public ProducerFactory<String, String> producerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
+  }
+
+  @Bean
+  public Map<String, Object> producerConfigs() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return configProps;
+  }
+}
+

--- a/src/main/java/com/baedal/delivery/config/RedisConfig.java
+++ b/src/main/java/com/baedal/delivery/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.baedal.delivery.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+    redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    return container;
+  }
+}

--- a/src/main/java/com/baedal/delivery/config/RedisConfig.java
+++ b/src/main/java/com/baedal/delivery/config/RedisConfig.java
@@ -24,7 +24,8 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory connectionFactory) {
     RedisMessageListenerContainer container = new RedisMessageListenerContainer();
     container.setConnectionFactory(connectionFactory);
     return container;

--- a/src/main/java/com/baedal/delivery/domain/model/CreateDelivery.java
+++ b/src/main/java/com/baedal/delivery/domain/model/CreateDelivery.java
@@ -1,0 +1,23 @@
+package com.baedal.delivery.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreateDelivery {
+
+  private final Long orderId;
+
+  private final Long storeId;
+
+  private final Long customerId;
+
+  private final DeliveryStatus status = DeliveryStatus.PENDING;
+
+  @Builder
+  public CreateDelivery(Long orderId, Long storeId, Long customerId) {
+    this.orderId = orderId;
+    this.storeId = storeId;
+    this.customerId = customerId;
+  }
+}

--- a/src/main/java/com/baedal/delivery/domain/model/Delivery.java
+++ b/src/main/java/com/baedal/delivery/domain/model/Delivery.java
@@ -3,10 +3,19 @@ package com.baedal.delivery.domain.model;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @Getter
-public class UpdateDeliveryStatus {
+@Builder
+public class Delivery {
 
   private Long id;
+
+  private Long orderId;
+
+  private Long storeId;
+
+  private Long customerId;
+
+  private Long riderId;
+
   private DeliveryStatus status;
 }

--- a/src/main/java/com/baedal/delivery/domain/model/DeliveryStatus.java
+++ b/src/main/java/com/baedal/delivery/domain/model/DeliveryStatus.java
@@ -2,4 +2,8 @@ package com.baedal.delivery.domain.model;
 
 public enum DeliveryStatus {
   PENDING, DELIVERING, DELIVERED;
+
+  public boolean isDelivered() {
+    return this == DELIVERED;
+  }
 }

--- a/src/main/java/com/baedal/delivery/domain/model/DeliveryStatus.java
+++ b/src/main/java/com/baedal/delivery/domain/model/DeliveryStatus.java
@@ -1,0 +1,5 @@
+package com.baedal.delivery.domain.model;
+
+public enum DeliveryStatus {
+  PENDING, DELIVERING, DELIVERED;
+}

--- a/src/main/java/com/baedal/delivery/domain/model/UpdateDeliveryStatus.java
+++ b/src/main/java/com/baedal/delivery/domain/model/UpdateDeliveryStatus.java
@@ -1,0 +1,13 @@
+package com.baedal.delivery.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UpdateDeliveryStatus {
+
+  private Long id;
+  private DeliveryStatus status;
+
+}

--- a/src/main/java/com/baedal/delivery/util/ObjectMapperUtil.java
+++ b/src/main/java/com/baedal/delivery/util/ObjectMapperUtil.java
@@ -1,0 +1,30 @@
+package com.baedal.delivery.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class ObjectMapperUtil {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  static {
+    mapper.registerModule(new JavaTimeModule());
+  }
+
+  public static String toJson(Object obj) {
+    try {
+      return mapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static <T> T jsonToDto(String value, Class<T> type) {
+    try {
+      return mapper.readValue(value, type);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,3 +4,8 @@ spring:
       bootstrap-servers: localhost:10000
     producer:
       bootstrap-servers: localhost:10000
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,6 @@
+spring:
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:10000
+    producer:
+      bootstrap-servers: localhost:10000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=delivery

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,4 +17,4 @@ redis:
       ttl: 1h
 
   channel-format:
-    delivery-update: "delivery:update:%d"
+    delivery-update: "delivery:update:store:%d"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: delivery
+  profiles:
+    active: local
 
 server:
   port: 8090
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,14 @@ spring:
 server:
   port: 8090
 
+redis:
+  key-format:
+    delivery-status:
+      key: "delivery:%d:status"
+      ttl: 30m
+    delivery-store:
+      key: "delivery:store:%d:active-deliveries"
+      ttl: 1h
+
+  channel-format:
+    delivery-update: "delivery:update:%d"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  application:
+    name: delivery
+
+server:
+  port: 8090

--- a/src/test/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapperTest.java
+++ b/src/test/java/com/baedal/delivery/adapter/out/persistence/mapper/DeliveryPersistenceMapperTest.java
@@ -1,0 +1,35 @@
+package com.baedal.delivery.adapter.out.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baedal.delivery.adapter.out.persistence.entity.DeliveryEntity;
+import com.baedal.delivery.adapter.out.persistence.enums.DeliveryEntityStatus;
+import com.baedal.delivery.domain.model.CreateDelivery;
+import com.baedal.delivery.domain.model.DeliveryStatus;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class DeliveryPersistenceMapperTest {
+
+  private DeliveryPersistenceMapper mapper = Mappers.getMapper(DeliveryPersistenceMapper.class);
+
+  @Test
+  void toEnum() {
+    DeliveryEntityStatus entityStatus = mapper.toEntityStatus(DeliveryStatus.PENDING);
+    assertThat(entityStatus).isEqualTo(DeliveryEntityStatus.PENDING);
+  }
+
+  @Test
+  void toDeliveryEntity() {
+    CreateDelivery model = CreateDelivery.builder()
+        .storeId(2L)
+        .orderId(1L)
+        .customerId(3L)
+        .build();
+
+    DeliveryEntity entity = mapper.toEntity(model);
+
+    assertThat(entity).isNotNull();
+    assertThat(entity.getStatus()).isEqualTo(DeliveryEntityStatus.PENDING);
+  }
+}

--- a/src/test/java/com/baedal/delivery/util/ObjectMapperUtilTest.java
+++ b/src/test/java/com/baedal/delivery/util/ObjectMapperUtilTest.java
@@ -1,0 +1,23 @@
+package com.baedal.delivery.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ObjectMapperUtilTest {
+
+  @Test
+  void string_toJson() {
+    String hello = ObjectMapperUtil.toJson("hello");
+    System.out.println("hello = " + hello);
+  }
+
+  @Test
+  void string_jsonToDto() {
+    assertThatThrownBy(() -> {
+          String hello = ObjectMapperUtil.jsonToDto("hello", String.class);
+          System.out.println("hello = " + hello);
+        }
+    ).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/src/test/java/com/baedal/delivery/util/ObjectMapperUtilTest.java
+++ b/src/test/java/com/baedal/delivery/util/ObjectMapperUtilTest.java
@@ -3,6 +3,7 @@ package com.baedal.delivery.util;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.baedal.delivery.domain.model.DeliveryStatus;
+import com.baedal.delivery.domain.model.UpdateDeliveryStatus;
 import org.junit.jupiter.api.Test;
 
 class ObjectMapperUtilTest {
@@ -25,6 +26,16 @@ class ObjectMapperUtilTest {
   @Test
   void enum_toJson() {
     String json = ObjectMapperUtil.toJson(DeliveryStatus.DELIVERED);
+    System.out.println("json = " + json);
+  }
+
+  @Test
+  void model_toJson() {
+    UpdateDeliveryStatus model = UpdateDeliveryStatus.builder()
+        .id(1L)
+        .status(DeliveryStatus.PENDING)
+        .build();
+    String json = ObjectMapperUtil.toJson(model);
     System.out.println("json = " + json);
   }
 }

--- a/src/test/java/com/baedal/delivery/util/ObjectMapperUtilTest.java
+++ b/src/test/java/com/baedal/delivery/util/ObjectMapperUtilTest.java
@@ -2,6 +2,7 @@ package com.baedal.delivery.util;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.baedal.delivery.domain.model.DeliveryStatus;
 import org.junit.jupiter.api.Test;
 
 class ObjectMapperUtilTest {
@@ -19,5 +20,11 @@ class ObjectMapperUtilTest {
           System.out.println("hello = " + hello);
         }
     ).isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void enum_toJson() {
+    String json = ObjectMapperUtil.toJson(DeliveryStatus.DELIVERED);
+    System.out.println("json = " + json);
   }
 }


### PR DESCRIPTION
### 리뷰 요청

 SSE 연결도 만들고 Redis pub/sub 기술도 사용하다 보니 여러 기술이 얽혀버렸고 직접 의존을 없애고자 구현 어댑터에서 서로의 의존을 `application/port/out` 으로 표현했습니다. 관련 모듈을 아래에 남겨두었습니다.

 캐시 hit/miss 시 조회 로직을 `DeliveryService.getStoresDeliveryStatus`(매우 지저분)에서 작성했는데 캐시 조회/저장 로직을 어디서 맡는게 옳을지 고민입니다. 서비스에서 작성하니 어떤 때는 캐시조회를 하다가 어디서는 빼먹는 일관적이지 못할 수 있다는 점이 신경쓰입니다. 저희 아키텍처 상 어댑터는 하나의 기술만을 추상적으로 사용하기에 여기서 맡는 것도 어려운 상황으로 보입니다.

### 매장 배달 상태 조회 SSE 연결 및 배달 업데이트 시 SSE push 동작 과정
```mermaid
sequenceDiagram
  autonumber
  actor C as Owner
  participant O as DeliveryService
  participant S as RedisSubscription
  participant P as RedisPublisher
  participant DB as RDB
  participant R as Redis

  C->>O: GET /{storeId}/stream (배달 조회)
  O->>S: Redis 채널 구독 시작 (delivery:update:{storeId})
  O-->>C: SseEmitter 반환 (SSE 연결)

  loop 배달 상태 변경 발생 시
    O->>DB: 배달 상태 영속화
    O-->>R: 캐시 저장 (delivery:{deliveryId}:status)
    O-->>P: Redis publish (delivery:update:store:{storeId})
    P-->>S: 
    S->>O: 상태 변경 수신 (onMessage)
    O-->>C: SSE로 배달 상태 전송
  end
```

### SSE 연결 생성 후 기존 배달 상태 조회
```mermaid
sequenceDiagram
  autonumber
  actor C as Owner
  participant Ctrl as Controller
  participant Service as DeliveryService
  participant Redis as Redis (Cache)
  participant DB as RDB
  participant Sse as SseEmitterManager

  C-)Ctrl: GET /{storeId}/notify-ready
  Ctrl->>Service: store의 active-deliveries 조회
  
  Service->>Redis: delivery:store:{storeId}:active-deliveries 조회
  alt 매장 배달 목록 캐시 미스
	  Service->>DB: 매장 배달 목록 조회
    Service-->>Redis: 캐시 저장
  end

  loop 매장 배달 목록 순회
    Service->>Redis: delivery:{deliveryId}:status 조회
    alt 배달 상태 캐시 미스
      Service->>DB: 배달 상태 조회
      Service-->>Redis: 캐시 저장
    end
  end
  Service->>Sse: SSE 초기 상태 전송
  Sse-)C: 
```

### SSE 연결 관련 모듈
- `GET /v0/{storeId}/stream` 매장에 SSE 연결 생성
- `GET /v0/{storeId}/notify-ready`매장으로 부터 sse 연결 준비됨을 받고 매장의 기존 배달 상태 조회
- `StoreSseEmitterManager`:  매장 SSE 연결 관리
- `DeliveryStatusSubscriptionAdapter`: redis channel 구독 관리

### 배달 상태 업데이트 발행 관련 모듈
- `DeliveryService`: 비즈니스 로직 수행 중 배달 상태 변경 발생 시 앱 이벤트 발행
- `EventPublisherAdapter`: Spring의 ApplicationEventPublisher이용해 앱 내 이벤트 발행
- `DeliveryEventHandler`: ApplicationEventPublisher가 발행한 이벤트를 처리하는 진입점
- `DeliveryCacheAdapter`: 배달 상태 캐싱
- `DeliveryMessagePublisherAdapter`: 배달 상태 변경을 Redis Publisher 이용해 발행

### 배달 상태 업데이트 구독 관련 모듈
- `DeliveryStatusListener`: 구독중인 redis channel에서 메시지를 받음
- `DeliveryStatusPushService`: DeliveryStatusSender 메시지 송신 위임
- `DeliveryStatusSenderAdapter`: StoreSseEmitterManager 메시지 송신 위임
- `StoreSseEmitterManager`: 연결된 매장에 메시지 push
